### PR TITLE
Ensure options variable is declared before usage in header

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -13,10 +13,7 @@
     function ssoLegacy(token) {
         const url = `https://${window.location.hostname}/legacy_sso.asp?access_token=${encodeURI(token)}`;
 
-        if (window.location.hostname != 'ratebeer.com') {
-            const options = { method: 'GET', credentials: 'include' };
-        }
-
+        const options = { method: 'GET', credentials: 'include' };
         return fetch(url, options).then((res) => res.text())
         .then((json) => {
             const incoming = JSON.parse(json);


### PR DESCRIPTION
Ensure options variable is declared before usage in header

fixes:
![image](https://user-images.githubusercontent.com/23247631/31303204-aa4d35e4-aad7-11e7-8471-4ef51169de4d.png)
